### PR TITLE
Adding the templating caching template finder for non-local deployments

### DIFF
--- a/www/conf/prod.py
+++ b/www/conf/prod.py
@@ -17,5 +17,12 @@ DATABASES = {
     },
 }
 
+TEMPLATE_LOADERS = (
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
+)
+
 EMAIL_SUBJECT_PREFIX = '[{{ project_code }}][Prod] '
 LOG_ROOT = os.path.join(os.path.dirname(__file__), '../../../logs/prod')

--- a/www/conf/stage.py
+++ b/www/conf/stage.py
@@ -17,5 +17,12 @@ DATABASES = {
     },
 }
 
+TEMPLATE_LOADERS = (
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
+)
+
 EMAIL_SUBJECT_PREFIX = '[{{ project_code }}][Stage] '
 LOG_ROOT = os.path.join(os.path.dirname(__file__), '../../../logs/stage')

--- a/www/conf/test.py
+++ b/www/conf/test.py
@@ -17,5 +17,12 @@ DATABASES = {
     },
 }
 
+TEMPLATE_LOADERS = (
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
+)
+
 EMAIL_SUBJECT_PREFIX = '[{{ project_code }}][Test] '
 LOG_ROOT = os.path.join(os.path.dirname(__file__), '../../../logs/test')


### PR DESCRIPTION
Template caching makes quite an impact to site performance, especially with complex templates such as those used in Oscar.

See the 'django.template.loaders.cached.Loader' on https://docs.djangoproject.com/en/dev/ref/templates/api/#loader-types for more details. In particular check the note about template tags and thread safety.
