### PR TITLE
Adding OSCAR_MAIN_TEMPLATE_DIR to default.py

### DIFF
--- a/www/conf/default_oscar.py
+++ b/www/conf/default_oscar.py
@@ -110,8 +110,11 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'urls'
 
+from oscar import OSCAR_MAIN_TEMPLATE_DIR
+
 TEMPLATE_DIRS = (
     location('templates'),
+    OSCAR_MAIN_TEMPLATE_DIR
 )
 
 INSTALLED_APPS = [


### PR DESCRIPTION
The oscar main template path was not present in default.py
