### PR TITLE
"localhost" implies localhost over IP

### DIFF
--- a/www/conf/local.py
+++ b/www/conf/local.py
@@ -11,7 +11,7 @@ DATABASES = {
         'NAME': location('db.sqlite3'),                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': '',                      # Set to empty string for peer (local non-IP socket). Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
     },
 }

--- a/www/conf/prod.py
+++ b/www/conf/prod.py
@@ -6,7 +6,7 @@ DATABASES = {
         'NAME': '{{ project_code }}_prod', # Or path to database file if using sqlite3.
         'USER': '{{ project_code}}_app', # Not used with sqlite3.
         'PASSWORD': '', # Not used with sqlite3.
-        'HOST': '', # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': '', # Set to empty string for peer (local non-IP socket). Not used with sqlite3.
         'PORT': '', # Set to empty string for default. Not used with sqlite3.
     },
 }

--- a/www/conf/stage.py
+++ b/www/conf/stage.py
@@ -6,7 +6,7 @@ DATABASES = {
         'NAME': '{{ project_code }}_stage', # Or path to database file if using sqlite3.
         'USER': '{{ project_code}}_app', # Not used with sqlite3.
         'PASSWORD': '', # Not used with sqlite3.
-        'HOST': '', # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': '', # Set to empty string for peer (local non-IP socket). Not used with sqlite3.
         'PORT': '', # Set to empty string for default. Not used with sqlite3.
     },
 }

--- a/www/conf/test.py
+++ b/www/conf/test.py
@@ -6,7 +6,7 @@ DATABASES = {
         'NAME': '{{ project_code }}_test', # Or path to database file if using sqlite3.
         'USER': '{{ project_code}}_app', # Not used with sqlite3.
         'PASSWORD': '', # Not used with sqlite3.
-        'HOST': '', # Set to empty string for localhost. Not used with sqlite3.
+        'HOST': '', # Set to empty string for peer (local non-IP socket). Not used with sqlite3.
         'PORT': '', # Set to empty string for default. Not used with sqlite3.
     },
 }


### PR DESCRIPTION
Not a big change - even better would be to get rid of these comments entirely - they encourage devs to make assumptions instead of going to the documentation.
